### PR TITLE
styles: change header width to max-width.

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -9,7 +9,7 @@ export const Container = styled.div<ContainerProps>`
   padding: 30px 0;
 
   header {
-    width: 1120px;
+    max-width: 1120px;
     margin: 0 auto;
     padding: ${({ size }) => (size === 'small' ? '0 20px ' : '0 20px 150px')};
     display: flex;


### PR DESCRIPTION
To make the header responsive. When decreasing the browser window, the header remained fixed and the "Listing" and "Import" menus were hidden