### PR TITLE
style: disable react/prop-types eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,8 @@
         "ts": "never",
         "tsx": "never"
       }
-    ]
+    ],
+    "react/prop-types": "off"
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
Hello there! 😄 

Since the project template is using TypeScript, we shouldn't worry about warning related with missed static ``PropTypes Declarations``

Refer to: 
![Screenshot at May 22 09-20-45](https://user-images.githubusercontent.com/48022589/82667108-9239f080-9c0d-11ea-9586-d4cd46b3d76d.png)
